### PR TITLE
Return gateway when not resolving host names

### DIFF
--- a/src/ifconfig.interfaces.js
+++ b/src/ifconfig.interfaces.js
@@ -177,7 +177,7 @@ function getBroadcastAddr(line) {
  * @return {string,null} default gateway ip or null
  */
 function getGateway(stdout) {
-  const re = new RegExp(`(?:(?:default)|(?:link-local)) +([^ ]+)`)
+  const re = new RegExp(`(?:(?:default)|(?:link-local)|(?:0.0.0.0)) +([^ ]+)`)
   const match = stdout.match(re)
   if (match === null) return null
 

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -22,5 +22,6 @@ module.exports = {
   route_get_1: fs.readFileSync(path.resolve(__dirname, './route_get_1.txt'), 'utf8'),
   route_get_2: fs.readFileSync(path.resolve(__dirname, './route_get_2.txt'), 'utf8'),
   route_get_3: fs.readFileSync(path.resolve(__dirname, './route_get_3.txt'), 'utf8'),
-  route_get_4: fs.readFileSync(path.resolve(__dirname, './route_get_4.txt'), 'utf8')
+  route_get_4: fs.readFileSync(path.resolve(__dirname, './route_get_4.txt'), 'utf8'),
+  route_get_5: fs.readFileSync(path.resolve(__dirname, './route_get_5.txt'), 'utf8')
 };

--- a/test/fixtures/route_get_5.txt
+++ b/test/fixtures/route_get_5.txt
@@ -1,0 +1,4 @@
+Kernel IP routing table
+Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
+0.0.0.0         192.168.10.1    0.0.0.0         UG    202    0        0 enxb827ebf6e3b1
+192.168.10.0    0.0.0.0         255.255.255.0   U     202    0        0 enxb827ebf6e3b1

--- a/test/ifconfig.interfaces.test.js
+++ b/test/ifconfig.interfaces.test.js
@@ -244,5 +244,30 @@ describe('ifconfig', function () {
         done();
       });
     });
+
+    it('should list interfaces with correct gateway when not resolving hostname', function (done) {
+      execMock.stdout.push(fixtures.ifconfig_get_5);
+      execMock.stdout.push(fixtures.route_get_5);
+      ifconfig.interfaces(function (err, interfaces) {
+        t.strictEqual(err, null);
+        t.strictEqual(interfaces.length, 2);
+        t.deepEqual(interfaces, [{
+          name: 'eth0',
+          ip: '1.1.1.77',
+          netmask: '1.1.1.0',
+          broadcast: '1.1.1.255',
+          mac: 'aa:aa:aa:aa:aa:aa',
+          gateway: '192.168.10.1'
+        }, {
+          name: 'lo',
+          ip: '127.0.0.1',
+          netmask: '255.0.0.0',
+          broadcast: null,
+          mac: null,
+          gateway: '192.168.10.1'
+        }]);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
As described in https://github.com/FGRibreau/network-config/issues/35 the gateway is not resolved when using `route -n` because the regex doesn't match anymore.

This PR simply adds `0.0.0.0` to the candidates when resolving the gateway.